### PR TITLE
Simplify server: remove manual SSL/Let's Encrypt cert handling

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,15 +1,12 @@
-const https = require('https');
 const http = require('http');
 const fs = require('fs');
 const url = require('url');
 const dotenv = require('dotenv');
 
 dotenv.config();
-console.info(process.env);
 
-const HTTPS = !!parseInt(process.env.HTTPS);
 const HOSTNAME = '0.0.0.0';
-const PORT = HTTPS ? 443 : 8082;
+const PORT = process.env.PORT || 8082;
 
 const ALLOWED_ORIGINS = [
   // 'http://localhost:8080',
@@ -17,17 +14,6 @@ const ALLOWED_ORIGINS = [
   'https://filippoitaliano.github.io',
   'https://garden.filippoitaliano.com'
 ];
-
-const createServer = (callback) => {
-  if (HTTPS) {
-    return https.createServer({
-      key: fs.readFileSync(process.env.SSL_KEY),
-      cert: fs.readFileSync(process.env.SSL_CERT),
-    }, callback);
-  } else {
-    return http.createServer(callback);
-  }
-}
 
 const updateGenericLog = () => {
   const logPath = '../data/generic.log';
@@ -62,7 +48,7 @@ const articleCache = (() => {
   return JSON.stringify(parsedWithImages);
 })()
 
-const server = createServer((request, response) => {
+const server = http.createServer((request, response) => {
   const { origin } = request.headers;
   if (ALLOWED_ORIGINS.includes(origin)) {
     response.setHeader('Access-Control-Allow-Origin', origin);

--- a/server/dotenv.md
+++ b/server/dotenv.md
@@ -1,3 +1,2 @@
-This env variables are required to start the server with HTTPS:
-- SSL_CERT
-- SSL_KEY
+The server listens on `process.env.PORT` (provided automatically by Render) and falls back to `8082` locally.
+No other env variables are required to start the server.

--- a/server/package.json
+++ b/server/package.json
@@ -1,10 +1,7 @@
 {
   "license": "MIT",
   "scripts": {
-    "start-dev": "SET HTTPS=0 && node app.js",
-    "start-prod": "SET HTTPS=1 && node app.js",
-    "start-dev-linux": "export HTTPS=0 && node app.js",
-    "start-prod-linux": "export HTTPS=1 && node app.js"
+    "start": "node app.js"
   },
   "dependencies": {
     "dotenv": "^12.0.3"


### PR DESCRIPTION
## Summary
- Render terminates TLS at its edge and forwards plain HTTP to the app, so the manual Let's Encrypt cert handling (`HTTPS` env var, `SSL_KEY`/`SSL_CERT` read from disk, `https.createServer` branch) in `server/app.js` was dead complexity.
- Server now always listens over HTTP on `process.env.PORT` (injected by Render, falls back to `8082` locally).
- Removed a stray `console.info(process.env)` debug log that printed all env vars.
- Simplified `server/package.json` scripts (`start-dev`/`start-prod`/`*-linux`) down to a single `start` script.
- Updated `server/dotenv.md` to drop the now-unused `SSL_CERT`/`SSL_KEY` requirements.

## Test plan
- [x] `npm install` in `server/` and ran `node app.js` locally — server starts on port 8082 and `GET /articles` returns `200`.
- [ ] Deploy to Render and confirm the service starts and serves traffic as expected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NDaVpaHAMXX4ufF3spE9zs)_